### PR TITLE
Skipping test is not helpful in unit test jobs

### DIFF
--- a/jenkins/jobs/dsl/java_reference_application_jobs.groovy
+++ b/jenkins/jobs/dsl/java_reference_application_jobs.groovy
@@ -117,12 +117,11 @@ unitTestJob.with{
       }
     }
     maven{
-      goals('clean test -DskipTests')
+      goals('clean test')
       mavenInstallation("ADOP Maven")
     }
   }
   publishers{
-    archiveArtifacts("**/*")
     downstreamParameterized{
       trigger(projectFolderName + "/Reference_Application_Code_Analysis"){
         condition("UNSTABLE_OR_BETTER")


### PR DESCRIPTION
This change is required to actually perform the tests in unit test job.