### PR TITLE
SonarQube versioning and multi-tenancy support

### DIFF
--- a/jenkins/jobs/dsl/java_reference_application_jobs.groovy
+++ b/jenkins/jobs/dsl/java_reference_application_jobs.groovy
@@ -3,6 +3,7 @@ def workspaceFolderName = "${WORKSPACE_NAME}"
 def projectFolderName = "${PROJECT_NAME}"
 
 // Variables
+def projectNameKey = projectFolderName.toLowerCase().replace("/", "-")
 def referenceAppgitRepo = "spring-petclinic"
 def regressionTestGitRepo = "adop-cartridge-java-regression-tests"
 def referenceAppGitUrl = "ssh://jenkins@gerrit:29418/${PROJECT_NAME}/" + referenceAppgitRepo
@@ -133,6 +134,7 @@ codeAnalysisJob.with {
     environmentVariables {
         env('WORKSPACE_NAME', workspaceFolderName)
         env('PROJECT_NAME', projectFolderName)
+        env('PROJECT_NAME_KEY', projectNameKey)
     }
     wrappers {
         preBuildCleanup()
@@ -151,9 +153,9 @@ codeAnalysisJob.with {
     configure { myProject ->
         myProject / builders << 'hudson.plugins.sonar.SonarRunnerBuilder'(plugin: "sonar@2.2.1") {
             project('sonar-project.properties')
-            properties('''sonar.projectKey=org.java.reference-application
-sonar.projectName=Reference application
-sonar.projectVersion=1.0.0
+            properties('''sonar.projectKey=${PROJECT_NAME_KEY}
+sonar.projectName=${PROJECT_NAME}
+sonar.projectVersion=1.0.${B}
 sonar.sources=src
 sonar.language=java
 sonar.sourceEncoding=UTF-8

--- a/src/test/groovy/com/java/cartridge/CodeAnalysisReferenceApplicationJobSpec.groovy
+++ b/src/test/groovy/com/java/cartridge/CodeAnalysisReferenceApplicationJobSpec.groovy
@@ -81,7 +81,7 @@ class CodeAnalysisReferenceApplicationJobSpec extends Specification {
             }
     }
 
-    def 'workspace_name and project_name env variables injected'() {
+    def 'workspace_name, project_name and project_name_key env variables injected'() {
         expect:
             node.properties.EnvInjectJobProperty.size() == 1
 
@@ -92,7 +92,7 @@ class CodeAnalysisReferenceApplicationJobSpec extends Specification {
                     propertiesContent.size() == 1
 
                     with(propertiesContent) {
-                        text() == "WORKSPACE_NAME=${workspaceName}\nPROJECT_NAME=${projectName}"
+                        text() == "WORKSPACE_NAME=${workspaceName}\nPROJECT_NAME=${projectName}\nPROJECT_NAME_KEY=${projectNameKey}"
                     }
                 }
             }
@@ -100,6 +100,7 @@ class CodeAnalysisReferenceApplicationJobSpec extends Specification {
         where:
             workspaceName = helper.workspaceName
             projectName = helper.projectName
+            projectNameKey = helper.projectName.toLowerCase().replace("/", "-")
     }
 
     def 'job assigned to java8 node'() {
@@ -217,9 +218,9 @@ class CodeAnalysisReferenceApplicationJobSpec extends Specification {
                 properties.size() == 1
 
                 with(properties) {
-                    text() == "sonar.projectKey=org.java.reference-application\n" +
-                        "sonar.projectName=Reference application\n" +
-                        "sonar.projectVersion=1.0.0\n" +
+                    text() == 'sonar.projectKey=${PROJECT_NAME_KEY}' + "\n" +
+                        'sonar.projectName=${PROJECT_NAME}' + "\n" +
+                        'sonar.projectVersion=1.0.${B}' + "\n" +
                         "sonar.sources=src\n" +
                         "sonar.language=java\n" +
                         "sonar.sourceEncoding=UTF-8\n" +


### PR DESCRIPTION
We had two issues:
1. Each build will overwrite previous one because we had hardcoded version value 1.0.0 so we are loosing support of versioning where we can compare quality of our code between builds.
2. If we would create new project and load java cartridge, our pipeline will overwrite data which was added from other projects which also use java cartridge, because had hardcoded project name and project key values. 

Solution is very simple:
```
sonar.projectKey=${PROJECT_NAME_KEY}
sonar.projectName=${PROJECT_NAME}
sonar.projectVersion=1.0.${B}
```