### PR TITLE
2 times faster deployments

### DIFF
--- a/jenkins/jobs/dsl/java_reference_application_jobs.groovy
+++ b/jenkins/jobs/dsl/java_reference_application_jobs.groovy
@@ -198,6 +198,7 @@ deployJob.with {
         copyArtifacts("Reference_Application_Build") {
             buildSelector {
                 buildNumber('${B}')
+                includePatterns('target/petclinic.war')
             }
         }
         shell('''set +x
@@ -452,6 +453,7 @@ deployJobToProdA.with {
         copyArtifacts("Reference_Application_Build") {
             buildSelector {
                 buildNumber('${B}')
+                includePatterns('target/petclinic.war')
             }
         }
         shell('''
@@ -509,6 +511,7 @@ deployJobToProdB.with {
         copyArtifacts("Reference_Application_Build") {
             buildSelector {
                 buildNumber('${B}')
+                includePatterns('target/petclinic.war')
             }
         }
         shell('''|export SERVICE_NAME="$(echo ${PROJECT_NAME} | tr '/' '_')_${ENVIRONMENT_NAME}"

--- a/src/test/groovy/com/java/cartridge/DeployReferenceApplicationJobSpec.groovy
+++ b/src/test/groovy/com/java/cartridge/DeployReferenceApplicationJobSpec.groovy
@@ -230,6 +230,21 @@ class DeployReferenceApplicationJobSpec extends Specification {
             jenkinsJobName = 'Reference_Application_Build'
     }
 
+    @Unroll
+    def 'Copy Artifacts include pattern specified only on "#includePattern" file'() {
+        expect:
+            with(node.builders['hudson.plugins.copyartifact.CopyArtifact']) {
+                filter.size() == 1
+
+                with(filter) {
+                    text() == includePattern
+                }
+            }
+
+        where:
+            includePattern = 'target/petclinic.war'
+    }
+
     def 'pipeline automatic trigger exists'() {
         expect:
             node.publishers.size() == 1


### PR DESCRIPTION
Minor change, instead of copying everything from Build job workspace, for deploy jobs now we are copying only 1 needed file with application. 2 times faster :)

Before:
```
Copied 2,574 artifacts from "ExampleWorkspace ? ExampleProject ? Reference_Application_Build" build number 1
Took 51 sec on Swarm_Slave-dd40627e
```

After:
```
Copied 1 artifact from "ExampleWorkspace ? ExampleProject ? Reference_Application_Build" build number 1
Took 25 sec on Swarm_Slave-dd40627e
```