### PR TITLE
Adding solutions for issues 93 and 95

### DIFF
--- a/jenkins/jobs/dsl/java_reference_application_jobs.groovy
+++ b/jenkins/jobs/dsl/java_reference_application_jobs.groovy
@@ -289,7 +289,7 @@ regressionTestJob.with {
             |#JOB_WORKSPACE_PATH="$(docker inspect --format '{{ .Mounts.Networks.'"$DOCKER_NETWORK_NAME"'.IPAddress }}' ${CONTAINER_NAME} )/${JOB_NAME}"
             |echo JOB_WORKSPACE_PATH=$JOB_WORKSPACE_PATH >> env.properties
             |mkdir -p ${JOB_WORKSPACE_PATH}/owasp_zap_proxy/test-results
-            |docker run -it -d --net=$DOCKER_NETWORK_NAME -v ${JOB_WORKSPACE_PATH}/owasp_zap_proxy/test-results/:/opt/zaproxy/test-results/ --name ${CONTAINER_NAME} -P nhantd/owasp_zap start zap-test
+            |docker run -it -d --net=$DOCKER_NETWORK_NAME -v ${JOB_WORKSPACE_PATH}/owasp_zap_proxy/test-results/:/opt/zaproxy/test-results/ -e affinity:container==jenkins-slave --name ${CONTAINER_NAME} -P nhantd/owasp_zap start zap-test
             |
             |sleep 30s
             |ZAP_IP=$( docker inspect --format '{{ .NetworkSettings.Networks.'"$DOCKER_NETWORK_NAME"'.IPAddress }}' ${CONTAINER_NAME} )
@@ -311,7 +311,7 @@ regressionTestJob.with {
             |docker stop ${CONTAINER_NAME}
             |docker rm ${CONTAINER_NAME}
             |
-            |docker run -i --net=$DOCKER_NETWORK_NAME -v ${JOB_WORKSPACE_PATH}/owasp_zap_proxy/test-results/:/opt/zaproxy/test-results/ --name ${CONTAINER_NAME} -P nhantd/owasp_zap stop zap-test
+            |docker run -i --net=$DOCKER_NETWORK_NAME -v ${JOB_WORKSPACE_PATH}/owasp_zap_proxy/test-results/:/opt/zaproxy/test-results/ -e affinity:container==jenkins-slave --name ${CONTAINER_NAME} -P nhantd/owasp_zap stop zap-test
             |docker cp ${CONTAINER_NAME}:/opt/zaproxy/test-results/zap-test-report.html .
             |sleep 10s
             |docker rm ${CONTAINER_NAME}

--- a/jenkins/jobs/dsl/java_reference_application_jobs.groovy
+++ b/jenkins/jobs/dsl/java_reference_application_jobs.groovy
@@ -383,7 +383,7 @@ performanceTestJob.with {
             |if [ -e ../apache-jmeter-2.13.tgz ]; then
             |	cp ../apache-jmeter-2.13.tgz $JMETER_TESTDIR
             |else
-            |	wget http://www.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz
+            |	wget https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz
             |    cp apache-jmeter-2.13.tgz ../
             |    mv apache-jmeter-2.13.tgz $JMETER_TESTDIR
             |fi


### PR DESCRIPTION
Hi @nickdgriffin,

In one commit there is the solution for [issue 93 - Reference_Application_Performance_Tests job failing due to not finding apache-jmeter-2.13.tgz](https://github.com/Accenture/adop-docker-compose/issues/93)

In another commit there is the solution for [issue 95 - Reference_Application_Regression_Tests job randomly failing because the 2 containers are not created on the same host](https://github.com/Accenture/adop-docker-compose/issues/95). 