### PR TITLE
jmeter distribution URL fixed

### DIFF
--- a/jenkins/jobs/dsl/java_reference_application_jobs.groovy
+++ b/jenkins/jobs/dsl/java_reference_application_jobs.groovy
@@ -383,7 +383,7 @@ performanceTestJob.with {
             |if [ -e ../apache-jmeter-2.13.tgz ]; then
             |	cp ../apache-jmeter-2.13.tgz $JMETER_TESTDIR
             |else
-            |	wget http://www.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz
+            |	wget https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz
             |    cp apache-jmeter-2.13.tgz ../
             |    mv apache-jmeter-2.13.tgz $JMETER_TESTDIR
             |fi


### PR DESCRIPTION
Reference_Application_Performance_Tests job was failing and throwing error below:

```
+ wget http://www.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz
--2016-06-09 14:34:11--  http://www.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz
Resolving www.apache.org (www.apache.org)... 88.198.26.2, 140.211.11.105, 2a01:4f8:130:2192::2
Connecting to www.apache.org (www.apache.org)|88.198.26.2|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2016-06-09 14:34:11 ERROR 404: Not Found.
```

wget URL is not longer valid and we need to change it to https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz

I've changed into my forked repository and its working.

This PR will fix issue 93 of adop-docker-compose: https://github.com/Accenture/adop-docker-compose/issues/93