### PR TITLE
Updated job DSL test dependency version to 1.48

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compile 'org.codehaus.groovy:groovy:2.4.6'
-    compile 'org.jenkins-ci.plugins:job-dsl-core:1.39'
+    compile 'org.jenkins-ci.plugins:job-dsl-core:1.48'
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude module: 'groovy-all'
     }


### PR DESCRIPTION
This reflects the current version of the job DSL plugin used in adop-jenkins (https://github.com/Accenture/adop-jenkins/blob/master/resources/plugins.txt#L63)

Tested using;

`gradlew clean test`

All tests passed as expected.