### PR TITLE
remove the pattern plain: from gerrit trigger!

### DIFF
--- a/jenkins/jobs/dsl/java_reference_application_jobs.groovy
+++ b/jenkins/jobs/dsl/java_reference_application_jobs.groovy
@@ -48,7 +48,7 @@ buildAppJob.with {
         env('PROJECT_NAME', projectFolderName)
     }
     label("java8")
-    triggers scmProvider.trigger(projectScmNamespace, referenceAppgitRepo, 'plain:master')
+    triggers scmProvider.trigger(projectScmNamespace, referenceAppgitRepo, 'master')
     steps {
         maven {
             goals('clean install -DskipTests')


### PR DESCRIPTION
Hi,
In the DevOps Academy session while running through Module - 02 lab activity the build job does not gets trigger. 

Removing the **_plain:_** from the gerrit trigger pattern of Reference Application Build job then after saving changes to this job it gets executed on code push done to master branch.